### PR TITLE
Closes #3   Feature/rate limiting auth

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,3 +38,14 @@ PLATFORM_SECRET=S...your_platform_stellar_secret_key
 # Key used to encrypt/decrypt custodial wallet secrets stored in DB
 # Use a strong, random string — at least 32 characters
 WALLET_ENCRYPTION_KEY=your_wallet_encryption_key_here
+
+
+# ─── Rate Limiting ────────────────────────────────────────────────────────
+RATE_LIMIT_LOGIN_MAX=10
+RATE_LIMIT_LOGIN_WINDOW_MS=900000
+
+RATE_LIMIT_REGISTER_MAX=5
+RATE_LIMIT_REGISTER_WINDOW_MS=3600000
+
+RATE_LIMIT_API_MAX=100
+RATE_LIMIT_API_WINDOW_MS=60000

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -1,0 +1,45 @@
+const rateLimit = require('express-rate-limit');
+
+const getEnv = (key, fallback) => {
+    const value = process.env[key];
+    return value ? Number(value) : fallback;
+};
+
+// LOGIN — allows 10 attempts per 15 mins
+const loginLimiter = rateLimit({
+    windowMs: getEnv('RATE_LIMIT_LOGIN_WINDOW_MS', 15 * 60 * 1000),
+    max: getEnv('RATE_LIMIT_LOGIN_MAX', 10),
+    message: {
+        error: 'Demasiados intentos de inicio de sesión. Inténtalo de nuevo en 15 minutos.',
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+
+// REGISTER — allows 5 attempts per hour
+const registerLimiter = rateLimit({
+    windowMs: getEnv('RATE_LIMIT_REGISTER_WINDOW_MS', 60 * 60 * 1000),
+    max: getEnv('RATE_LIMIT_REGISTER_MAX', 5),
+    message: {
+        error: 'Demasiadas cuentas creadas desde esta IP. Inténtalo de nuevo en una hora.',
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+
+// GLOBAL API — 100 / minute
+const apiLimiter = rateLimit({
+    windowMs: getEnv('RATE_LIMIT_API_WINDOW_MS', 60 * 1000),
+    max: getEnv('RATE_LIMIT_API_MAX', 100),
+    message: {
+        error: 'Demasiadas solicitudes. Inténtalo de nuevo en un momento.',
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+
+module.exports = {
+    loginLimiter,
+    registerLimiter,
+    apiLimiter,
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.4.1",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.3.1"
       },
@@ -720,6 +721,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -1077,6 +1096,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.4.1",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.3.1"
   },

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,10 +1,14 @@
 const express = require('express');
+const {
+    loginLimiter,
+    registerLimiter
+} = require('../middleware/rateLimiter');
 const { register, login, logout, refresh } = require('../controllers/authController');
 
 const router = express.Router();
 
-router.post('/register', register);
-router.post('/login', login);
+router.post('/login', loginLimiter, login);
+router.post('/register', registerLimiter, register);
 router.post('/logout', logout);
 router.post('/refresh', refresh);
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,12 +31,11 @@ app.use((req, res, next) => {
 });
 
 
-
-app.use('/api', apiLimiter);
-
 // ── Body parsers (after CORS) ──
 app.use(express.json());
 app.use(cookieParser());
+
+app.use('/api', apiLimiter);
 
 // ── Database Connection ──
 mongoose.connect(process.env.MONGO_URI || 'mongodb://localhost:27017/proofwork')

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,12 +3,16 @@ const mongoose = require('mongoose');
 const dotenv = require('dotenv');
 const cookieParser = require('cookie-parser');
 
+const { apiLimiter } = require('./middleware/rateLimiter');
+
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 5000;
 
 const ALLOWED_ORIGINS = ['http://localhost:3000', 'http://localhost:3001'];
+
+app.set('trust proxy', 1);
 
 // ── CORS ── must be the VERY FIRST middleware
 app.use((req, res, next) => {
@@ -25,6 +29,10 @@ app.use((req, res, next) => {
   }
   next();
 });
+
+
+
+app.use('/api', apiLimiter);
 
 // ── Body parsers (after CORS) ──
 app.use(express.json());


### PR DESCRIPTION

## Summary

This PR adds rate limiting to authentication endpoints to prevent brute force attacks on login and abuse of the registration endpoint.

The system introduces IP-based throttling for auth routes as well as a global API rate limiter to protect backend resources.

---

## Changes Introduced

### 1. Rate limiter middleware

Added `express-rate-limit` and implemented three separate limiters:

* **Login limiter**

  * 10 requests per 15 minutes per IP
  * Protects against brute-force login attempts

* **Register limiter**

  * 5 requests per hour per IP
  * Prevents spam account creation and on-chain wallet abuse

* **Global API limiter**

  * 100 requests per minute per IP
  * Applied to all `/api` routes

All limiters are configurable via environment variables.

---

### 2. Middleware integration

* Applied `loginLimiter` to:

  * `POST /auth/login`

* Applied `registerLimiter` to:

  * `POST /auth/register`

* Applied `apiLimiter` globally to:

  * `/api` routes

* Enabled `trust proxy` in Express to ensure correct IP detection behind proxies.

---

### 3. Environment configuration

Added support for the following environment variables:

* `RATE_LIMIT_LOGIN_MAX`
* `RATE_LIMIT_LOGIN_WINDOW_MS`
* `RATE_LIMIT_REGISTER_MAX`
* `RATE_LIMIT_REGISTER_WINDOW_MS`
* `RATE_LIMIT_API_MAX`
* `RATE_LIMIT_API_WINDOW_MS`

---

### 4. Response behavior

* Rate-limited requests return `429 Too Many Requests`

* Responses include:

  * `RateLimit-Limit`
  * `RateLimit-Remaining`
  * `RateLimit-Reset`
  * `Retry-After`

* Error messages are returned in Spanish as specified.

---

## Security Improvements

* Prevents brute-force login attempts
* Prevents automated spam account creation
* Reduces risk of on-chain wallet abuse via `/auth/register`
* Adds basic API abuse protection across all endpoints

---

## Testing

Verified using repeated curl requests:

* Login endpoint correctly returns `429` after 10 attempts within 15 minutes
* Register endpoint correctly returns `429` after 5 attempts within 1 hour
* Rate limit headers are present and updating correctly
* Reset behavior works after window expiration

---

## Notes

* `/auth/refresh` and `/auth/logout` are intentionally excluded from strict rate limiting to avoid unintended session disruptions.
* Middleware order ensures body parsing occurs before rate limiting to avoid request parsing issues.
* Designed to work behind reverse proxies (Railway/Render/Nginx) using `trust proxy`.

Closes #3
