### PR TITLE
feat: build public landing page with value prop and CTAs

### DIFF
--- a/frontend/src/app/landing/Features.tsx
+++ b/frontend/src/app/landing/Features.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React from 'react';
+import { Lock, Globe, Cpu, Zap, CreditCard, BarChart3 } from 'lucide-react';
+
+export default function Features() {
+  const features = [
+    {
+      icon: <Lock className="w-6 h-6" />,
+      title: 'Escrow Descentralizado',
+      desc: 'Los fondos se bloquean en un contrato inteligente y solo se liberan cuando el trabajo es aprobado.'
+    },
+    {
+      icon: <Globe className="w-6 h-6" />,
+      title: 'Ecosistema Stellar',
+      desc: 'Aprovechamos la red Stellar para transacciones globales, rápidas y con comisiones casi nulas.'
+    },
+    {
+      icon: <BarChart3 className="w-6 h-6" />,
+      title: 'Reputación Inmutable',
+      desc: 'Cada proyecto completado y cada reseña se guarda on-chain, creando un currículum imposible de falsificar.'
+    },
+    {
+      icon: <CreditCard className="w-6 h-6" />,
+      title: 'Pagos en MXNe',
+      desc: 'Evita la volatilidad con la stablecoin del peso mexicano, lista para ser convertida a fiat.'
+    },
+    {
+      icon: <Zap className="w-6 h-6" />,
+      title: 'Contratos 1:1 y Retos',
+      desc: 'Desde contrataciones directas hasta eventos de competencia para encontrar al mejor candidato.'
+    },
+    {
+      icon: <Cpu className="w-6 h-6" />,
+      title: 'Tecnología Soroban',
+      desc: 'Smart contracts de última generación que garantizan la lógica de negocio sin fallos.'
+    }
+  ];
+
+  return (
+    <section id="features" className="py-24">
+      <div className="max-w-7xl mx-auto px-6">
+        <div className="text-center mb-20">
+          <h2 className="text-4xl font-bold text-white mb-4">Tecnología que genera confianza</h2>
+          <p className="text-white/50 max-w-2xl mx-auto">
+            Eliminamos la incertidumbre del trabajo remoto con herramientas de Web3 diseñadas para el mundo real.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {features.map((feature, i) => (
+            <div key={i} className="card p-8 group hover:border-[#2185D5]/50 transition-all">
+              <div className="w-12 h-12 rounded-xl bg-[#2185D5]/5 flex items-center justify-center text-[#60b8f0] mb-6 group-hover:scale-110 transition-transform">
+                {feature.icon}
+              </div>
+              <h3 className="text-xl font-semibold text-white mb-3">{feature.title}</h3>
+              <p className="text-white/40 leading-relaxed text-sm">{feature.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/landing/Footer.tsx
+++ b/frontend/src/app/landing/Footer.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { Twitter, Github, Linkedin, ExternalLink } from 'lucide-react';
+
+export default function Footer() {
+  return (
+    <footer className="py-12 border-t border-white/5 bg-[#050508]">
+      <div className="max-w-7xl mx-auto px-6">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-12 mb-12">
+          <div className="col-span-1 md:col-span-2">
+            <Link href="/" className="flex items-center gap-2 mb-6">
+              <span className="text-white font-bold text-2xl tracking-tight">Nuup</span>
+            </Link>
+            <p className="text-white/40 max-w-sm mb-6">
+              Conectando el talento de México con el mundo a través de tecnología blockchain. 
+              Seguridad, transparencia y reputación.
+            </p>
+            <div className="flex items-center gap-4">
+              <a href="#" className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center text-white/40 hover:text-white hover:bg-[#2185D5]/20 transition-all">
+                <Twitter className="w-5 h-5" />
+              </a>
+              <a href="#" className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center text-white/40 hover:text-white hover:bg-[#2185D5]/20 transition-all">
+                <Github className="w-5 h-5" />
+              </a>
+              <a href="#" className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center text-white/40 hover:text-white hover:bg-[#2185D5]/20 transition-all">
+                <Linkedin className="w-5 h-5" />
+              </a>
+            </div>
+          </div>
+
+          <div>
+            <h4 className="text-white font-semibold mb-6">Plataforma</h4>
+            <ul className="space-y-4">
+              <li><Link href="/events" className="text-white/40 hover:text-white text-sm transition-colors">Eventos</Link></li>
+              <li><Link href="/projects" className="text-white/40 hover:text-white text-sm transition-colors">Proyectos</Link></li>
+              <li><Link href="/freelancers" className="text-white/40 hover:text-white text-sm transition-colors">Freelancers</Link></li>
+              <li><Link href="/auth/register" className="text-white/40 hover:text-white text-sm transition-colors">Únete</Link></li>
+            </ul>
+          </div>
+
+          <div>
+            <h4 className="text-white font-semibold mb-6">Recursos</h4>
+            <ul className="space-y-4">
+              <li><a href="#" className="text-white/40 hover:text-white text-sm flex items-center gap-1">Stellar Network <ExternalLink className="w-3 h-3" /></a></li>
+              <li><a href="#" className="text-white/40 hover:text-white text-sm flex items-center gap-1">MXNe Stablecoin <ExternalLink className="w-3 h-3" /></a></li>
+              <li><a href="#" className="text-white/40 hover:text-white text-sm transition-colors">Documentación</a></li>
+              <li><a href="#" className="text-white/40 hover:text-white text-sm transition-colors">Soporte</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="pt-8 border-t border-white/5 flex flex-col md:row items-center justify-between gap-4">
+          <p className="text-white/20 text-xs">
+            © {new Date().getFullYear()} Nuup. Todos los derechos reservados.
+          </p>
+          <div className="flex items-center gap-6">
+            <a href="#" className="text-white/20 hover:text-white text-xs transition-colors">Privacidad</a>
+            <a href="#" className="text-white/20 hover:text-white text-xs transition-colors">Términos</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/app/landing/Hero.tsx
+++ b/frontend/src/app/landing/Hero.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import Button from '@/components/ui/Button';
+import { ArrowRight, Shield, Zap, Coins } from 'lucide-react';
+
+export default function Hero() {
+  return (
+    <section className="relative pt-32 pb-20 overflow-hidden">
+      {/* Background Glows */}
+      <div className="glow-orb w-[500px] h-[500px] bg-[#2185D5] top-[-10%] right-[-5%] opacity-10" />
+      <div className="glow-orb w-[400px] h-[400px] bg-[#818cf8] bottom-[10%] left-[-5%] opacity-5" />
+
+      <div className="max-w-7xl mx-auto px-6 relative z-10">
+        <div className="text-center max-w-4xl mx-auto">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/5 border border-white/10 mb-8 animate-fade-up">
+            <span className="w-2 h-2 rounded-full bg-[#60b8f0] animate-pulse" />
+            <span className="text-xs font-medium text-white/70 uppercase tracking-wider">
+              La nueva era del freelancing en México
+            </span>
+          </div>
+          
+          <h1 className="text-5xl md:text-7xl font-bold text-white mb-6 leading-tight animate-fade-up delay-100">
+            Conecta con talento <span className="gradient-text">verificado</span> on-chain
+          </h1>
+          
+          <p className="text-xl text-white/60 mb-10 leading-relaxed animate-fade-up delay-150">
+            Nuup es la plataforma que garantiza pagos seguros con escrow en Stellar y reputación inmutable. 
+            Sin intermediarios abusivos, solo talento real y resultados tangibles.
+          </p>
+          
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 animate-fade-up delay-200">
+            <Link href="/auth/register?role=recruiter">
+              <Button size="lg" className="h-14 px-8 text-base">
+                Publica un reto
+                <ArrowRight className="ml-2 w-5 h-5" />
+              </Button>
+            </Link>
+            <Link href="/auth/register?role=freelancer">
+              <Button variant="secondary" size="lg" className="h-14 px-8 text-base">
+                Encuentra trabajo
+              </Button>
+            </Link>
+          </div>
+        </div>
+
+        {/* Feature quick bits */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mt-24 animate-fade-up delay-300">
+          <div className="glass-panel p-6 rounded-2xl flex items-center gap-4">
+            <div className="w-12 h-12 rounded-xl bg-[#2185D5]/10 flex items-center justify-center text-[#60b8f0]">
+              <Shield className="w-6 h-6" />
+            </div>
+            <div>
+              <h3 className="text-white font-semibold">Escrow Seguro</h3>
+              <p className="text-white/40 text-sm">Fondos protegidos en Stellar</p>
+            </div>
+          </div>
+          <div className="glass-panel p-6 rounded-2xl flex items-center gap-4">
+            <div className="w-12 h-12 rounded-xl bg-[#818cf8]/10 flex items-center justify-center text-[#818cf8]">
+              <Zap className="w-6 h-6" />
+            </div>
+            <div>
+              <h3 className="text-white font-semibold">Reputación On-Chain</h3>
+              <p className="text-white/40 text-sm">Historial verificado e inmutable</p>
+            </div>
+          </div>
+          <div className="glass-panel p-6 rounded-2xl flex items-center gap-4">
+            <div className="w-12 h-12 rounded-xl bg-[#60b8f0]/10 flex items-center justify-center text-[#60b8f0]">
+              <Coins className="w-6 h-6" />
+            </div>
+            <div>
+              <h3 className="text-white font-semibold">Pagos en MXNe</h3>
+              <p className="text-white/40 text-sm">Estabilidad y rapidez local</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/landing/HowItWorks.tsx
+++ b/frontend/src/app/landing/HowItWorks.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import React from 'react';
+import { UserPlus, Briefcase, CheckCircle, Search, Rocket, Star } from 'lucide-react';
+
+export default function HowItWorks() {
+  const recruiterSteps = [
+    {
+      icon: <Briefcase className="w-6 h-6" />,
+      title: 'Publica un reto',
+      desc: 'Define los requisitos, el presupuesto y las fechas de entrega.'
+    },
+    {
+      icon: <Search className="w-6 h-6" />,
+      title: 'Selecciona talento',
+      desc: 'Evalúa portafolios con reputación on-chain verificada.'
+    },
+    {
+      icon: <CheckCircle className="w-6 h-6" />,
+      title: 'Libera el pago',
+      desc: 'El pago se libera automáticamente al validar la entrega.'
+    }
+  ];
+
+  const freelancerSteps = [
+    {
+      icon: <UserPlus className="w-6 h-6" />,
+      title: 'Crea tu perfil',
+      desc: 'Registra tu wallet y empieza a construir tu reputación.'
+    },
+    {
+      icon: <Star className="w-6 h-6" />,
+      title: 'Aplica a proyectos',
+      desc: 'Participa en eventos y gana proyectos según tu nivel.'
+    },
+    {
+      icon: <Rocket className="w-6 h-6" />,
+      title: 'Gana y crece',
+      desc: 'Recibe pagos en MXNe y sube de nivel en el ranking.'
+    }
+  ];
+
+  return (
+    <section id="how-it-works" className="py-24 bg-[#0a0a0f]">
+      <div className="max-w-7xl mx-auto px-6">
+        <div className="text-center mb-20">
+          <h2 className="text-4xl font-bold text-white mb-4">¿Cómo funciona Nuup?</h2>
+          <p className="text-white/50 max-w-2xl mx-auto">
+            Un ecosistema diseñado para la transparencia y eficiencia en el trabajo remoto.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
+          {/* Recruiters */}
+          <div className="space-y-10">
+            <h3 className="text-2xl font-semibold text-[#60b8f0] flex items-center gap-3">
+              Para Reclutadores
+            </h3>
+            <div className="space-y-8">
+              {recruiterSteps.map((step, i) => (
+                <div key={i} className="flex gap-6 items-start">
+                  <div className="w-12 h-12 rounded-2xl bg-white/5 border border-white/10 flex items-center justify-center shrink-0 text-white">
+                    {step.icon}
+                  </div>
+                  <div>
+                    <h4 className="text-white font-medium text-lg mb-1">{step.title}</h4>
+                    <p className="text-white/40 leading-relaxed">{step.desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Freelancers */}
+          <div className="space-y-10">
+            <h3 className="text-2xl font-semibold text-[#818cf8] flex items-center gap-3">
+              Para Freelancers
+            </h3>
+            <div className="space-y-8">
+              {freelancerSteps.map((step, i) => (
+                <div key={i} className="flex gap-6 items-start">
+                  <div className="w-12 h-12 rounded-2xl bg-white/5 border border-white/10 flex items-center justify-center shrink-0 text-white">
+                    {step.icon}
+                  </div>
+                  <div>
+                    <h4 className="text-white font-medium text-lg mb-1">{step.title}</h4>
+                    <p className="text-white/40 leading-relaxed">{step.desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/landing/LandingNavbar.tsx
+++ b/frontend/src/app/landing/LandingNavbar.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { Menu, X } from 'lucide-react';
+import Button from '@/components/ui/Button';
+
+function HexLogo() {
+  return (
+    <svg width="22" height="24" viewBox="0 0 20 22" fill="none" xmlns="http://www.w3.org/2000/svg"
+      className="transition-transform duration-300 group-hover:scale-110">
+      <defs>
+        <linearGradient id="hexGrad" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#2185D5" />
+          <stop offset="100%" stopColor="#818cf8" />
+        </linearGradient>
+      </defs>
+      <path d="M10 0L19.5 5.5V16.5L10 22L0.5 16.5V5.5L10 0Z" fill="url(#hexGrad)" />
+      <path d="M10 4L16.5 7.75V15.25L10 19L3.5 15.25V7.75L10 4Z" fill="rgba(0,0,0,0.35)" />
+    </svg>
+  );
+}
+
+export default function LandingNavbar() {
+  const [scrolled, setScrolled] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 20);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const navLinks = [
+    { name: 'Cómo funciona', href: '#how-it-works' },
+    { name: 'Características', href: '#features' },
+    { name: 'Testimonios', href: '#testimonials' },
+  ];
+
+  return (
+    <nav
+      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 h-16 ${
+        scrolled ? 'navbar-glass py-2' : 'bg-transparent py-4'
+      }`}
+    >
+      <div className="max-w-7xl mx-auto px-6 h-full flex items-center justify-between">
+        <Link href="/" className="flex items-center gap-2 group">
+          <HexLogo />
+          <span className="text-white font-bold text-xl tracking-tight transition-colors duration-200 group-hover:text-[#60b8f0]">
+            Nuup
+          </span>
+        </Link>
+
+        {/* Desktop Nav */}
+        <div className="hidden md:flex items-center gap-8">
+          {navLinks.map((link) => (
+            <a
+              key={link.name}
+              href={link.href}
+              className="text-white/70 hover:text-white text-sm font-medium transition-colors"
+            >
+              {link.name}
+            </a>
+          ))}
+          <div className="flex items-center gap-3 ml-4">
+            <Link href="/auth/login">
+              <Button variant="ghost" size="sm">Iniciar Sesión</Button>
+            </Link>
+            <Link href="/auth/register">
+              <Button size="sm">Regístrate</Button>
+            </Link>
+          </div>
+        </div>
+
+        {/* Mobile Toggle */}
+        <button
+          className="md:hidden text-white p-2"
+          onClick={() => setMobileOpen(!mobileOpen)}
+        >
+          {mobileOpen ? <X /> : <Menu />}
+        </button>
+      </div>
+
+      {/* Mobile Menu */}
+      {mobileOpen && (
+        <div className="absolute top-full left-0 right-0 bg-[#050508] border-b border-white/10 p-6 md:hidden animate-fade-in">
+          <div className="flex flex-col gap-6">
+            {navLinks.map((link) => (
+              <a
+                key={link.name}
+                href={link.href}
+                className="text-white/70 hover:text-white text-lg font-medium"
+                onClick={() => setMobileOpen(false)}
+              >
+                {link.name}
+              </a>
+            ))}
+            <hr className="border-white/10" />
+            <div className="flex flex-col gap-3">
+              <Link href="/auth/login" className="w-full">
+                <Button variant="secondary" className="w-full">Iniciar Sesión</Button>
+              </Link>
+              <Link href="/auth/register" className="w-full">
+                <Button className="w-full">Regístrate</Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/frontend/src/app/landing/SocialProof.tsx
+++ b/frontend/src/app/landing/SocialProof.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React from 'react';
+import { Quote } from 'lucide-react';
+
+export default function SocialProof() {
+  const testimonials = [
+    {
+      text: "Nuup cambió la forma en que contratamos. La reputación on-chain nos da la seguridad que ninguna otra plataforma ofrece.",
+      author: "Roberto G.",
+      role: "CTO en TechMexico"
+    },
+    {
+      text: "Como freelancer, lo que más valoro es el escrow. Sé que mi dinero está seguro desde que empiezo el reto.",
+      author: "Ana L.",
+      role: "Fullstack Developer"
+    },
+    {
+      text: "La rapidez de los pagos en MXNe es increíble. Por fin una plataforma que entiende el mercado mexicano.",
+      author: "Carlos M.",
+      role: "UI/UX Designer"
+    }
+  ];
+
+  return (
+    <section id="testimonials" className="py-24 bg-[#0a0a0f]">
+      <div className="max-w-7xl mx-auto px-6">
+        <div className="text-center mb-16">
+          <h2 className="text-3xl font-bold text-white mb-4">Lo que dicen de nosotros</h2>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {testimonials.map((t, i) => (
+            <div key={i} className="glass-panel p-8 rounded-2xl relative">
+              <Quote className="absolute top-6 right-8 w-8 h-8 text-white/5" />
+              <p className="text-white/70 italic mb-6 leading-relaxed">"{t.text}"</p>
+              <div>
+                <p className="text-white font-semibold">{t.author}</p>
+                <p className="text-white/30 text-xs">{t.role}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Placeholder Logos */}
+        <div className="mt-20 pt-10 border-t border-white/5">
+          <p className="text-center text-white/20 text-sm uppercase tracking-widest mb-10">Confían en nosotros</p>
+          <div className="flex flex-wrap justify-center gap-12 opacity-30 grayscale contrast-125">
+             <div className="text-2xl font-bold text-white">TECH-CO</div>
+             <div className="text-2xl font-bold text-white">MEX-DEV</div>
+             <div className="text-2xl font-bold text-white">SOLUTIONS</div>
+             <div className="text-2xl font-bold text-white">WEB3-HUB</div>
+             <div className="text-2xl font-bold text-white">BLOCK-MEX</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,25 +1,45 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/store/authStore';
 import Spinner from '@/components/ui/Spinner';
+import LandingNavbar from './landing/LandingNavbar';
+import Hero from './landing/Hero';
+import HowItWorks from './landing/HowItWorks';
+import Features from './landing/Features';
+import SocialProof from './landing/SocialProof';
+import Footer from './landing/Footer';
 
 export default function HomePage() {
   const { user } = useAuthStore();
   const router = useRouter();
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (user) {
       router.replace('/dashboard');
     } else {
-      router.replace('/auth/login');
+      setLoading(false);
     }
   }, [user, router]);
 
+  if (loading || user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#050508]">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-zinc-100">
-      <Spinner size="lg" />
-    </div>
+    <main className="min-h-screen bg-[#050508]">
+      <LandingNavbar />
+      <Hero />
+      <HowItWorks />
+      <Features />
+      <SocialProof />
+      <Footer />
+    </main>
   );
 }


### PR DESCRIPTION
This PR implements a comprehensive public-facing landing page at the root route (/). It
  provides potential users with a clear understanding of NUUP's value proposition, technical
  foundation (Stellar/Soroban), and clear calls-to-action for both recruiters and freelancers.

  Changes:
   - Replaced immediate login redirect in src/app/page.tsx with landing page rendering.
   - Created src/app/landing/ directory containing modular components:
       - LandingNavbar: Public navigation with anchor support.
       - Hero: headline, subheadline, and primary CTAs.
       - HowItWorks: Step-by-step guides for freelancers and recruiters.
       - Features: Technical highlights (Escrow, Reputation, MXNe).
       - SocialProof: Testimonials and trust indicators.
       - Footer: Extended navigation and social links.
   - Integrated existing design tokens for seamless visual consistency.

  How to test:
   1. Open the application at / while logged out.
   2. Verify the landing page renders with all sections (Hero, How it works, Features, etc.).
   3. Test responsiveness by resizing the browser.
   4. Click "Publica un reto" or "Encuentra trabajo" to ensure they lead to the registration
      page.
   5. Log in and verify that visiting / now correctly redirects you to /dashboard.

  Closes #1 